### PR TITLE
Update/init submodules before pulling

### DIFF
--- a/install
+++ b/install
@@ -63,6 +63,7 @@
     oops "could not download dapptools!"
   }
 
+  git submodule update --init
   git pull --quiet
 
   nix-env -Q -f . -iA dapp seth solc hevm ethsign

--- a/install
+++ b/install
@@ -63,7 +63,7 @@
     oops "could not download dapptools!"
   }
 
-  git submodule update --init
+  git submodule update --init --remote --quiet
   git pull --quiet
 
   nix-env -Q -f . -iA dapp seth solc hevm ethsign


### PR DESCRIPTION
Makes sure that they are initialized, even if the repo already had been
cloned without `--recursive`.