### PR TITLE
Don't install Nix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,10 @@ on:
   push:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@63cf434de4e4292c6960639d56c5dd550e789d77

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,9 @@ on:
   push:
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest ]
-    runs-on: ${{ matrix.os }}
+    # NOTE: see this issue for why we don't build on macOS
+    # https://github.community/t/api-rate-limit-exceeded-on-actions-setup-go/16237/5
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@63cf434de4e4292c6960639d56c5dd550e789d77

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,12 @@
+name: "Build"
+on:
+  pull_request:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@63cf434de4e4292c6960639d56c5dd550e789d77
+      - name: Run install script
+        run: ./install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-os:
-  - linux
-  - osx
-language: minimal
-sudo: required
-script:
-  sh install

--- a/_includes/install.html
+++ b/_includes/install.html
@@ -1,6 +1,8 @@
 <p class="lead">Setting up the DappHub toolkit</p>
 <p>
-  If you are running GNU/Linux or macOS you can take advantage of our all in one installer.
+  Dapptools requires Nix, so make sure you have it <a href="https://nixos.org/download.html">installed</a> first.
+
+  After that, you can take advantage of our one-line installer.
 </p>
 
 <pre>
@@ -8,7 +10,7 @@
 </pre>
 
 <p>
-  This script downloads the Nix package manager, setups binary cache with Cachix and installs our most used tools.
+  This script downloads the latest version of dapptools, sets up a binary cache using <a href="https://cachix.org">Cachix</a> and installs our most used tools.
 </p>
 
 <p class="lead">Manual installation</p>
@@ -19,10 +21,7 @@
 </p>
 
 <pre>
-<b>$ </b>curl https://nixos.org/nix/install | sh
+<b>$ </b>curl -L https://nixos.org/nix/install | sh
 <b>$ </b>. "$HOME/.nix-profile/etc/profile.d/nix.sh"
-<b>$ </b>nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
-<b>$ </b>cachix use dapp
-<b>$ </b>git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
-<b>$ </b>nix-env -f $HOME/.dapp/dapptools -iA dapp seth solc hevm ethsign
+<b>$ </b>nix-env -iA dapp hevm seth solc -if https://github.com/dapphub/dapptools/tarball/master --substituters https://dapp.cachix.org --trusted-public-keys dapp.cachix.org-1:9GJt9Ja8IQwR7YW/aF0QvCa6OmjGmsKoZIist0dG+Rs=
 </pre>

--- a/install
+++ b/install
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p cachix curl jq
+#! nix-shell --pure -i bash -p cacert cachix curl git jq nix
 
 { # Prevent execution if this script was only partially downloaded
   set -e

--- a/install
+++ b/install
@@ -20,7 +20,7 @@
   [[ $URL == null ]] && oops "Could not fetch latest release, please file an issue at https://github.com/dapphub/dapp-tools/issues/new"
 
   cachix use dapp
-  nix-env -iA dapp hevm seth -f "$URL"
+  nix-env -iA dapp hevm seth solc -f "$URL"
 
   echo -e "${GREEN}All set!${NC}"
 } # End of wrapping

--- a/install
+++ b/install
@@ -1,106 +1,21 @@
-#!/bin/sh
-
-# Based on the Nix install script
-# This script installs Nix, Cachix and Dapptools
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p cachix curl jq
 
 { # Prevent execution if this script was only partially downloaded
-
   set -e
-  
+
   oops() {
-    echo >&2 "${0##*/}: error:" "$@"
+    >&2 echo "error:" "$1"
     exit 1
   }
 
-  if [ "$(id -u)" -eq 0 ]; then
-    oops "please run this script as a regular user"
-  fi
+  [[ "$(id -u)" -eq 0 ]] && oops "Please run this script as a regular user"
 
-  if [ -z "$HOME" ]; then
-    oops "\$HOME is not set"
-  fi
+  URL=$(curl -sS https://api.github.com/repos/dapphub/dapptools/releases/latest | jq -r .tarball_url)
 
-  if [ -z "$USER" ]; then
-    oops "\$USER is not set"
-  fi
+  [[ $URL == null ]] && oops "Could not fetch latest release, please file an issue at https://github.com/dapphub/dapp-tools/issues/new"
 
-  have() { command -v "$1" >/dev/null; }
-
-  # We don't handle NixOS yet
-  { have nixos-version; } && {
-    echo >&2 "We love that you are running NixOS! <3"
-    echo >&2 "We're working on having this script work on NixOS, but for the moment"
-    echo >&2 "go to https://dapp.tools and follow manual installation instructions."
-    exit 1
-  }
-
-  # Don't auto update Nix v1.
-  { have nix-shell && ! have nix; } && {
-    echo >&2 "You seem to be running a Nix version lower than 2.0"
-    echo >&2 "Please upgrade to Nix v2 before running this script"
-    echo >&2 "You can run \`curl -sS https://nixos.org/nix/install | sh\`"
-    exit 1
-  }
-
-  { have git; } || oops "you need to install Git before running this script"
-  { have curl; } || oops "you need to install curl before running this script"
-
-  { have nix; } || {
-    echo "Dapptools uses the Nix package manager to install programs behind the scenes."
-    echo "Installing Nix in single-user mode, you may be asked for your sudo password."
-
-    curl -sS https://nixos.org/nix/install | sh
-
-    # shellcheck source=/dev/null
-    . "$HOME/.nix-profile/etc/profile.d/nix.sh"
-    echo "Nix installation succeded!"
-  }
-
-  if [ ! -d "$HOME/.config/nix" ]; then
-    mkdir -p "$HOME/.config/nix"
-  fi
-
-  if ! grep -q -F '# added by Dapptools installer' "$HOME/.config/nix/nix.conf"; then
-    echo "Adding Cachix binary cache to Nix"
-    cat <<EOF > "$HOME/.config/nix/nix.conf"
-# added by Dapptools installer
-substituters = https://cache.nixos.org https://dapp.cachix.org
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= dapp.cachix.org-1:9GJt9Ja8IQwR7YW/aF0QvCa6OmjGmsKoZIist0dG+Rs=
-EOF
-  fi
-
-  dest="$HOME/.dapp/"
-
-  if [ ! -d "$dest/dapptools" ]; then
-    echo "Downloading dapptools..."
-    mkdir -p "$dest"
-    cd "$dest"
-    git clone https://github.com/dapphub/dapptools --recursive --quiet
-    echo "Done."
-  fi
-
-  cd "$dest/dapptools" || {
-    oops "could not download dapptools!"
-  }
-
-  git submodule update --init --remote --quiet
-  git pull --quiet
-
-  echo "Installing dapptools... (this will take a while)"
-  nix-env -f . -iA dapp seth solc hevm ethsign
-
-  # Finished!
-  cat <<EOF
-
-Installation finished!
-
-You now have access to dapp, seth, solc, hevm and ethsign.
-
-Please logout and log back in to start using dapptools, or run
-
-    . "$HOME/.nix-profile/etc/profile.d/nix.sh"
-
-in this terminal.
-EOF
+  cachix use dapp
+  nix-env -iA dapp hevm seth -f "$URL"
 
 } # End of wrapping

--- a/install
+++ b/install
@@ -15,12 +15,13 @@
 
   [[ "$(id -u)" -eq 0 ]] && oops "Please run this script as a regular user"
 
-  URL=$(curl -sS https://api.github.com/repos/dapphub/dapptools/releases/latest | jq -r .tarball_url)
+  API_OUTPUT=$(curl -sS https://api.github.com/repos/dapphub/dapptools/releases/latest)
+  RELEASE=$(echo "$API_OUTPUT" | jq -r .tarball_url)
 
-  [[ $URL == null ]] && oops "Could not fetch latest release, please file an issue at https://github.com/dapphub/dapp-tools/issues/new"
+  [[ $RELEASE == null ]] && oops "No release found in ${API_OUTPUT}"
 
   cachix use dapp
-  nix-env -iA dapp hevm seth solc -f "$URL"
+  nix-env -iA dapp hevm seth solc -f "$RELEASE"
 
   echo -e "${GREEN}All set!${NC}"
 } # End of wrapping

--- a/install
+++ b/install
@@ -4,8 +4,12 @@
 { # Prevent execution if this script was only partially downloaded
   set -e
 
+  GREEN='\033[0;32m'
+  RED='\033[0;31m'
+  NC='\033[0m'
+
   oops() {
-    >&2 echo "error:" "$1"
+    >&2 echo -e "${RED}error:${NC} $1"
     exit 1
   }
 
@@ -18,4 +22,5 @@
   cachix use dapp
   nix-env -iA dapp hevm seth -f "$URL"
 
+  echo -e "${GREEN}All set!${NC}"
 } # End of wrapping

--- a/install
+++ b/install
@@ -24,3 +24,5 @@
 
   echo -e "${GREEN}All set!${NC}"
 } # End of wrapping
+
+# vim: set ft=sh:


### PR DESCRIPTION
See https://github.com/dapphub/dapptools/pull/377.

Also switches to GitHub actions for CI.

**NOTE**: 

- only runs on GNU/Linux, because GitHub rate-limits the IP the macOS builders are on
- Don't know how this fails when nix is not installed, since the shebang uses `nix-env`
- The current latest dapptools release (`ethsign/0.15.0`) is getting compiled on both CI and my machine. Not sure why this is, hopefully it goes away with the next release.


Closes #15.
Closes #16.
Closes dapphub/dapptools#375.