### PR TITLE
install: run nix-shell in bash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,4 +11,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@63cf434de4e4292c6960639d56c5dd550e789d77
       - name: Run install script
-        run: ./install
+        run: cat install | sh

--- a/install
+++ b/install
@@ -1,9 +1,12 @@
-#!/usr/bin/env nix-shell
-#! nix-shell --pure -i bash -p cacert cachix curl git jq nix
+#!/usr/bin/env bash
 
 { # Prevent execution if this script was only partially downloaded
   set -e
 
+  tmpfile=$(mktemp --suffix dapptools)
+  trap 'rm $tmpfile' EXIT
+
+  cat > "$tmpfile" <<<EOF
   GREEN='\033[0;32m'
   RED='\033[0;31m'
   NC='\033[0m'
@@ -24,6 +27,9 @@
   nix-env -iA dapp hevm seth solc -f "$RELEASE"
 
   echo -e "${GREEN}All set!${NC}"
+EOF
+
+  nix-shell --pure -p cacert cachix curl git jq nix --run "bash $tmpfile"
 } # End of wrapping
 
 # vim: set ft=sh:

--- a/install
+++ b/install
@@ -6,7 +6,7 @@
   tmpfile=$(mktemp --suffix dapptools)
   trap 'rm $tmpfile' EXIT
 
-  cat > "$tmpfile" <<<EOF
+  cat > "$tmpfile" <<'EOF'
   GREEN='\033[0;32m'
   RED='\033[0;31m'
   NC='\033[0m'


### PR DESCRIPTION
nix-shell scripts can't be piped into a shell, because the shebang is
seen by the piped shell as just a comment, and therefore ignored.

Closes https://github.com/dapphub/dapptools/issues/425