### PR TITLE
install: fix for osx

### DIFF
--- a/install
+++ b/install
@@ -3,7 +3,7 @@
 { # Prevent execution if this script was only partially downloaded
   set -e
 
-  tmpfile=$(mktemp --suffix dapptools)
+  tmpfile=$(mktemp)
   trap 'rm $tmpfile' EXIT
 
   cat > "$tmpfile" <<'EOF'


### PR DESCRIPTION
uses an invocation of mktemp that should work cross platform.

should fix: https://github.com/dapphub/dapptools/issues/434