### PR TITLE
Don't install solc if already present in path

### DIFF
--- a/install
+++ b/install
@@ -24,7 +24,8 @@
   [[ $RELEASE == null ]] && oops "No release found in ${API_OUTPUT}"
 
   cachix use dapp
-  nix-env -iA dapp hevm seth solc -f "$RELEASE"
+  command -v solc >/dev/null || solc="solc"
+  nix-env -iA dapp hevm seth "$solc" -f "$RELEASE"
 
   echo -e "${GREEN}All set!${NC}"
 EOF


### PR DESCRIPTION
If solc is already in path, this will prevent it from being added again. It does not conflict with `dapp` or `seth` since those will still use the bundled nix version.