### PR TITLE
include nixos cache in manual install command

### DIFF
--- a/_includes/install.html
+++ b/_includes/install.html
@@ -23,5 +23,5 @@
 <pre>
 <b>$ </b>curl -L https://nixos.org/nix/install | sh
 <b>$ </b>. "$HOME/.nix-profile/etc/profile.d/nix.sh"
-<b>$ </b>nix-env -iA dapp hevm seth solc -if https://github.com/dapphub/dapptools/tarball/master --substituters https://dapp.cachix.org --trusted-public-keys dapp.cachix.org-1:9GJt9Ja8IQwR7YW/aF0QvCa6OmjGmsKoZIist0dG+Rs=
+<b>$ </b>nix-env -iA dapp hevm seth solc -if https://api.github.com/repos/dapphub/dapptools/tarball/master --option substituters "https://cache.nixos.org https://dapp.cachix.org" --option trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= dapp.cachix.org-1:9GJt9Ja8IQwR7YW/aF0QvCa6OmjGmsKoZIist0dG+Rs"
 </pre>


### PR DESCRIPTION
People running the previous command would not have the official nixos.org cache and so would perform a full from source bootstrap of all dapptools dependencies (including multiple gcc and at least one ghc version). 